### PR TITLE
make auth_plugin_for_username async.

### DIFF
--- a/mysql/examples/serve_auth.rs
+++ b/mysql/examples/serve_auth.rs
@@ -97,7 +97,7 @@ impl<W: io::Write + Send> AsyncMysqlShim<W> for Backend {
         "mysql_native_password"
     }
 
-    fn auth_plugin_for_username(&self, _user: &[u8]) -> &str {
+    async fn auth_plugin_for_username(&self, _user: &[u8]) -> &str {
         "mysql_native_password"
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

make auth_plugin_for_username async so we can call user_mgr.get_user()  in it.

part of https://github.com/datafuselabs/databend/issues/4351

