### PR TITLE
fix(mysql/sync): spawn to fix sync tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace -- --ignored
+          args: --workspace -- --include-ignored
 
   pass:
     name: All tests passed

--- a/mysql/tests/it/sync.rs
+++ b/mysql/tests/it/sync.rs
@@ -131,21 +131,20 @@ where
             .enable_all()
             .build()
             .unwrap();
-        let port = rt.block_on(async {
+
+        rt.spawn(async move {
             let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
             let port = listener.local_addr().unwrap().port();
             tokio::spawn(async move {
                 let (s, _) = listener.accept().await.unwrap();
                 AsyncMysqlIntermediary::run_on(self, s).await
             });
-            port
-        });
-        // rt.shutdown_background();
 
-        let mut db =
-            mysql::Conn::new(Opts::from_url(&format!("mysql://127.0.0.1:{}", port)).unwrap())
-                .unwrap();
-        c(&mut db);
+            let mut db =
+                mysql::Conn::new(Opts::from_url(&format!("mysql://127.0.0.1:{}", port)).unwrap())
+                    .unwrap();
+            c(&mut db);
+        });
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- fix(mysql/sync): spawn to fix sync tests
- chore(ci): enable all tests, not only `ignored`

The tests did not run correctly due to a previous setup error.

