### PR TITLE
chore: fix MySQL example ParamParser lifetime

### DIFF
--- a/mysql/README.md
+++ b/mysql/README.md
@@ -39,7 +39,7 @@ impl<W: io::Write + Send> AsyncMysqlShim<W> for Backend {
     async fn on_execute<'a>(
         &'a mut self,
         _: u32,
-        _: opensrv_mysql::ParamParser,
+        _: opensrv_mysql::ParamParser<'a>,
         results: QueryResultWriter<'a, W>,
     ) -> io::Result<()> {
         results.completed(OkResponse::default())

--- a/mysql/examples/serve_auth.rs
+++ b/mysql/examples/serve_auth.rs
@@ -43,7 +43,7 @@ impl<W: io::Write + Send> AsyncMysqlShim<W> for Backend {
     async fn on_execute<'a>(
         &'a mut self,
         _: u32,
-        _: opensrv_mysql::ParamParser,
+        _: opensrv_mysql::ParamParser<'a>,
         results: QueryResultWriter<'a, W>,
     ) -> io::Result<()> {
         let resp = OkResponse::default();

--- a/mysql/examples/serve_one.rs
+++ b/mysql/examples/serve_one.rs
@@ -40,7 +40,7 @@ impl<W: io::Write + Send> AsyncMysqlShim<W> for Backend {
     async fn on_execute<'a>(
         &'a mut self,
         _: u32,
-        _: opensrv_mysql::ParamParser,
+        _: opensrv_mysql::ParamParser<'a>,
         results: QueryResultWriter<'a, W>,
     ) -> io::Result<()> {
         results.completed(OkResponse::default())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix MySQL example ParamParser lifetime

```rust
error[E0495]: cannot infer an appropriate lifetime due to conflicting requirements
  --> mysql/examples/serve_one.rs:45:25
   |
45 |       ) -> io::Result<()> {
   |  _________________________^
46 | |         results.completed(OkResponse::default())
47 | |     }
   | |_____^
   |
```
