### PR TITLE
Update ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: apache/skywalking-eyes@main
+      - uses: apache/skywalking-eyes/header@501a28d2fb4a9b962661987e50cf0219631b32ff
         with:
           config: .github/licenserc.yaml
 


### PR DESCRIPTION
We have a dedicate GitHub actions for header check so this should be updated, and we don't recommend using `@main` so there is no unexpected behaviors when we have changes in our codebase.

See https://github.com/apache/skywalking-eyes/pull/123