### PR TITLE
feat: packet reader reduce bytes resize times

### DIFF
--- a/mysql/src/packet_reader.rs
+++ b/mysql/src/packet_reader.rs
@@ -145,6 +145,7 @@ impl<R: AsyncRead + Unpin> PacketReader<R> {
                     }
                     Err(nom::Err::Incomplete(_)) | Err(nom::Err::Error(_)) => {}
                     Err(nom::Err::Failure(ctx)) => {
+                        self.bytes.truncate(self.remaining);
                         return Err(io::Error::new(
                             io::ErrorKind::InvalidData,
                             format!("{:?}", ctx),
@@ -171,6 +172,7 @@ impl<R: AsyncRead + Unpin> PacketReader<R> {
             buffer_size = PACKET_LARGE_BUFFER_SIZE;
 
             if read == 0 {
+                self.bytes.truncate(self.remaining);
                 if self.bytes.is_empty() {
                     return Ok(None);
                 } else {

--- a/mysql/src/packet_reader.rs
+++ b/mysql/src/packet_reader.rs
@@ -18,6 +18,9 @@ use std::io::prelude::*;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncReadExt;
 
+const PACKET_BUFFER_SIZE: usize = 4_096;
+const PACKET_LARGE_BUFFER_SIZE: usize = 1_048_576;
+
 pub struct PacketReader<R> {
     bytes: Vec<u8>,
     start: usize,
@@ -123,6 +126,7 @@ impl<R: AsyncRead + Unpin> PacketReader<R> {
     pub async fn next_async(&mut self) -> io::Result<Option<(u8, Packet<'_>)>> {
         self.start = self.bytes.len() - self.remaining;
 
+        let mut buffer_size = PACKET_BUFFER_SIZE;
         loop {
             if self.remaining != 0 {
                 let bytes = {
@@ -131,11 +135,12 @@ impl<R: AsyncRead + Unpin> PacketReader<R> {
                     // out. however, without NLL, borrowck doesn't realize that self.bytes is no
                     // longer borrowed after the match, and so can be mutated.
                     let bytes = &self.bytes[self.start..];
-                    unsafe { ::std::slice::from_raw_parts(bytes.as_ptr(), bytes.len()) }
+                    unsafe { ::std::slice::from_raw_parts(bytes.as_ptr(), self.remaining) }
                 };
                 match packet(bytes) {
                     Ok((rest, p)) => {
                         self.remaining = rest.len();
+                        self.bytes.truncate(self.remaining);
                         return Ok(Some(p));
                     }
                     Err(nom::Err::Incomplete(_)) | Err(nom::Err::Error(_)) => {}
@@ -151,14 +156,19 @@ impl<R: AsyncRead + Unpin> PacketReader<R> {
             // we need to read some more
             self.bytes.drain(0..self.start);
             self.start = 0;
-            let end = self.bytes.len();
-            self.bytes.resize(std::cmp::max(4096, end * 2), 0);
+            let end = self.remaining;
+
+            if self.bytes.len() - end < buffer_size {
+                let new_len = std::cmp::max(buffer_size, end * 2);
+                self.bytes.resize(new_len, 0);
+            }
             let read = {
                 let buf = &mut self.bytes[end..];
                 self.r.read(buf).await?
             };
-            self.bytes.truncate(end + read);
-            self.remaining = self.bytes.len();
+            self.remaining = end + read;
+            // use a larger buffer size to reduce bytes resize times.
+            buffer_size = PACKET_LARGE_BUFFER_SIZE;
 
             if read == 0 {
                 if self.bytes.is_empty() {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

`PacketReader` will perform `truncate` and `resize` operations on `self.bytes` in each loop when reading data, which will have a great impact on performance when a large amount of data needs to be inserted.
This PR improves performance by reducing unnecessary `truncate` and `resize`.

The figure below shows the flame graph for inserting 20M data, `resize` needs to be executed in 9.62s before optimization, and 0.8s after optimization.

![image](https://user-images.githubusercontent.com/1070352/205474627-62f7da53-54c7-4d2e-a48d-cd2ef20af60d.png)

![image](https://user-images.githubusercontent.com/1070352/205474854-85535b97-13ab-4889-aacf-4b8f18bdeb7f.png)

related issue: https://github.com/datafuselabs/databend/issues/8988
