### PR TITLE
feat: add option to reject connection when dbname absence in login

### DIFF
--- a/mysql/src/lib.rs
+++ b/mysql/src/lib.rs
@@ -532,22 +532,20 @@ where
                         writer: &mut self.writer,
                     };
                     self.shim.on_init(db, w).await?;
+                } else if self.reject_connection_on_dbname_absence {
+                    writers::write_err(
+                        ErrorKind::ER_DATABASE_NAME,
+                        "database required on connection".as_bytes(),
+                        &mut self.writer,
+                    )
+                    .await?;
                 } else {
-                    if self.reject_connection_on_dbname_absence {
-                        writers::write_err(
-                            ErrorKind::ER_DATABASE_NAME,
-                            "database required on connection".as_bytes(),
-                            &mut self.writer,
-                        )
-                        .await?;
-                    } else {
-                        writers::write_ok_packet(
-                            &mut self.writer,
-                            self.client_capabilities,
-                            OkResponse::default(),
-                        )
-                        .await?;
-                    }
+                    writers::write_ok_packet(
+                        &mut self.writer,
+                        self.client_capabilities,
+                        OkResponse::default(),
+                    )
+                    .await?;
                 }
             }
 

--- a/mysql/src/tls.rs
+++ b/mysql/src/tls.rs
@@ -44,9 +44,11 @@ where
     let writer = PacketWriter::new(writer);
 
     let process_use_statement_on_query = opts.process_use_statement_on_query;
+    let reject_connection_on_dbname_absence = opts.reject_connection_on_dbname_absence;
     let mut mi = AsyncMysqlIntermediary {
         client_capabilities,
         process_use_statement_on_query,
+        reject_connection_on_dbname_absence,
         shim,
         reader,
         writer,
@@ -73,9 +75,11 @@ where
     let writer = PacketWriter::new(writer);
 
     let process_use_statement_on_query = opts.process_use_statement_on_query;
+    let reject_connection_on_dbname_absence = opts.reject_connection_on_dbname_absence;
     let mut mi = AsyncMysqlIntermediary {
         client_capabilities,
         process_use_statement_on_query,
+        reject_connection_on_dbname_absence,
         shim,
         reader,
         writer,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

In our scenario, database name is required in `LoginRequest` we know which database to use for this connection. This patch adds an option to reject connection without this data.

