### PR TITLE
fix: corrupt tls handshake caused by buffer over read

### DIFF
--- a/mysql/src/packet_reader.rs
+++ b/mysql/src/packet_reader.rs
@@ -142,6 +142,7 @@ impl<R: AsyncRead + Unpin> PacketReader<R> {
                         self.remaining = rest.len();
                         if self.remaining > 0 {
                             self.bytes = self.bytes.split_off(self.bytes.len() - self.remaining);
+                            self.start = 0;
                         }
                         return Ok(Some(p));
                     }

--- a/mysql/src/packet_reader.rs
+++ b/mysql/src/packet_reader.rs
@@ -103,15 +103,7 @@ impl<R: AsyncRead + Unpin> AsyncRead for PacketReader<R> {
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> std::task::Poll<io::Result<()>> {
         if self.remaining != 0 {
-            let bytes = {
-                // NOTE: this is all sorts of unfortunate. what we really want to do is to give
-                // &self.bytes[self.start..] to `packet()`, and the lifetimes should all work
-                // out. however, without NLL, borrowck doesn't realize that self.bytes is no
-                // longer borrowed after the match, and so can be mutated.
-                let bytes = &self.bytes[self.start..];
-                unsafe { ::std::slice::from_raw_parts(bytes.as_ptr(), bytes.len()) }
-            };
-            buf.put_slice(bytes);
+            buf.put_slice(&self.bytes[self.start..]);
             self.bytes.clear();
             self.start = 0;
             self.remaining = 0;
@@ -141,7 +133,7 @@ impl<R: AsyncRead + Unpin> PacketReader<R> {
                     Ok((rest, p)) => {
                         self.remaining = rest.len();
                         if self.remaining > 0 {
-                            self.bytes = self.bytes.split_off(self.bytes.len() - self.remaining);
+                            self.bytes = rest.to_vec();
                             self.start = 0;
                         }
                         return Ok(Some(p));

--- a/mysql/src/packet_reader.rs
+++ b/mysql/src/packet_reader.rs
@@ -140,7 +140,9 @@ impl<R: AsyncRead + Unpin> PacketReader<R> {
                 match packet(bytes) {
                     Ok((rest, p)) => {
                         self.remaining = rest.len();
-                        self.bytes.truncate(self.remaining);
+                        if self.remaining > 0 {
+                            self.bytes = self.bytes.split_off(self.bytes.len() - self.remaining);
+                        }
                         return Ok(Some(p));
                     }
                     Err(nom::Err::Incomplete(_)) | Err(nom::Err::Error(_)) => {}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This change fixes occasional issue with tls handshake. Due to the issue with truncating wrong part of buffer in reader,  the `rest` part of bytes are dropped. Tls stream will end up with invalid partial handshake packet and throws "received corrupt message" error.

### Why this only happens on Tls?

Because Tls is the only scenario that client sends two consecutive packets. A normal request-response packet requires reader to read to the end of a packet so it never leaves remaining data.

