### PR TITLE
feat: make version() return &str to String

### DIFF
--- a/mysql/examples/serve_auth.rs
+++ b/mysql/examples/serve_auth.rs
@@ -85,9 +85,9 @@ impl<W: AsyncWrite + Send + Unpin> AsyncMysqlShim<W> for Backend {
         username == "default".as_bytes()
     }
 
-    fn version(&self) -> &str {
+    fn version(&self) -> String {
         // 5.1.10 because that's what Ruby's ActiveRecord requires
-        "5.1.10-alpha-msql-proxy"
+        "5.1.10-alpha-msql-proxy".to_string()
     }
 
     fn connect_id(&self) -> u32 {

--- a/mysql/src/lib.rs
+++ b/mysql/src/lib.rs
@@ -113,9 +113,9 @@ pub trait AsyncMysqlShim<W: Send> {
     type Error: From<io::Error>;
 
     /// Server version
-    fn version(&self) -> &str {
+    fn version(&self) -> String {
         // 5.1.10 because that's what Ruby's ActiveRecord requires
-        "5.1.10-alpha-msql-proxy"
+        "5.1.10-alpha-msql-proxy".to_string()
     }
 
     /// Connection id


### PR DESCRIPTION
in db-proxy scenario, sometimes we want return version returned by upstream mysql servers. Maybe we should change the  version return type to String.

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/


