### PR TITLE
feat: add marashal/unmarshal support for large size integer types.

### DIFF
--- a/clickhouse/src/protocols/mod.rs
+++ b/clickhouse/src/protocols/mod.rs
@@ -33,17 +33,13 @@ pub enum Packet {
     Data(Block),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum Stage {
+    #[default]
     Default = 0,
     InsertPrepare,
     InsertStarted,
     EOS,
-}
-impl Default for Stage {
-    fn default() -> Self {
-        Stage::Default
-    }
 }
 
 pub const DBMS_MIN_REVISION_WITH_CLIENT_INFO: u64 = 54032;

--- a/components/micromarshal/Cargo.toml
+++ b/components/micromarshal/Cargo.toml
@@ -18,6 +18,7 @@ doctest = false
 
 [dependencies]
 ordered-float = "3.1.0"
+ethnum = "1.3"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/components/micromarshal/src/marshal.rs
+++ b/components/micromarshal/src/marshal.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use ethnum::{I256, U256};
 use ordered_float::OrderedFloat;
 
 pub trait Marshal {
@@ -45,6 +46,20 @@ impl Marshal for u64 {
     }
 }
 
+impl Marshal for u128 {
+    fn marshal(&self, scratch: &mut [u8]) {
+        let bytes = self.to_le_bytes();
+        scratch.copy_from_slice(&bytes);
+    }
+}
+
+impl Marshal for U256 {
+    fn marshal(&self, scratch: &mut [u8]) {
+        let bytes = self.to_le_bytes();
+        scratch.copy_from_slice(&bytes);
+    }
+}
+
 impl Marshal for i8 {
     fn marshal(&self, scratch: &mut [u8]) {
         scratch[0] = *self as u8;
@@ -66,6 +81,20 @@ impl Marshal for i32 {
 }
 
 impl Marshal for i64 {
+    fn marshal(&self, scratch: &mut [u8]) {
+        let bytes = self.to_le_bytes();
+        scratch.copy_from_slice(&bytes);
+    }
+}
+
+impl Marshal for i128 {
+    fn marshal(&self, scratch: &mut [u8]) {
+        let bytes = self.to_le_bytes();
+        scratch.copy_from_slice(&bytes);
+    }
+}
+
+impl Marshal for I256 {
     fn marshal(&self, scratch: &mut [u8]) {
         let bytes = self.to_le_bytes();
         scratch.copy_from_slice(&bytes);

--- a/components/micromarshal/src/unmarshal.rs
+++ b/components/micromarshal/src/unmarshal.rs
@@ -17,6 +17,8 @@ use std::io;
 use std::io::Error;
 use std::io::Result;
 
+use ethnum::I256;
+use ethnum::U256;
 use ordered_float::OrderedFloat;
 
 pub trait Unmarshal<T> {
@@ -50,6 +52,18 @@ impl Unmarshal<u64> for u64 {
     }
 }
 
+impl Unmarshal<u128> for u128 {
+    fn unmarshal(scratch: &[u8]) -> Self {
+        u128::from_le_bytes(scratch.try_into().unwrap())
+    }
+}
+
+impl Unmarshal<U256> for U256 {
+    fn unmarshal(scratch: &[u8]) -> Self {
+        U256::from_le_bytes(scratch.try_into().unwrap())
+    }
+}
+
 impl Unmarshal<i8> for i8 {
     fn unmarshal(scratch: &[u8]) -> Self {
         i8::from_le_bytes(scratch.try_into().unwrap())
@@ -71,6 +85,18 @@ impl Unmarshal<i32> for i32 {
 impl Unmarshal<i64> for i64 {
     fn unmarshal(scratch: &[u8]) -> Self {
         i64::from_le_bytes(scratch.try_into().unwrap())
+    }
+}
+
+impl Unmarshal<i128> for i128 {
+    fn unmarshal(scratch: &[u8]) -> Self {
+        i128::from_le_bytes(scratch.try_into().unwrap())
+    }
+}
+
+impl Unmarshal<I256> for I256 {
+    fn unmarshal(scratch: &[u8]) -> Self {
+        I256::from_le_bytes(scratch.try_into().unwrap())
     }
 }
 

--- a/components/micromarshal/tests/it/main.rs
+++ b/components/micromarshal/tests/it/main.rs
@@ -14,6 +14,8 @@
 
 use std::fmt;
 
+use ethnum::I256;
+use ethnum::U256;
 use micromarshal::*;
 use rand::distributions::Distribution;
 use rand::distributions::Standard;
@@ -23,6 +25,22 @@ mod statbuffer;
 
 use statbuffer::StatBuffer;
 
+trait Random {
+    fn random() -> Self;
+}
+
+impl Random for U256 {
+    fn random() -> Self {
+        U256::from_words(random(), random())
+    }
+}
+
+impl Random for I256 {
+    fn random() -> Self {
+        I256::from_words(random(), random())
+    }
+}
+
 fn test_some<T>()
 where
     T: Copy + fmt::Debug + StatBuffer + Marshal + Unmarshal<T> + PartialEq,
@@ -31,6 +49,21 @@ where
     for _ in 0..100 {
         let mut buffer = T::buffer();
         let v = random::<T>();
+
+        v.marshal(buffer.as_mut());
+        let u = T::unmarshal(buffer.as_ref());
+
+        assert_eq!(v, u);
+    }
+}
+
+fn test_some_large<T>()
+where
+    T: Copy + fmt::Debug + StatBuffer + Marshal + Unmarshal<T> + PartialEq + Random,
+{
+    for _ in 0..100 {
+        let mut buffer = T::buffer();
+        let v = T::random();
 
         v.marshal(buffer.as_mut());
         let u = T::unmarshal(buffer.as_ref());
@@ -60,6 +93,16 @@ fn test_u64() {
 }
 
 #[test]
+fn test_u128() {
+    test_some::<u128>()
+}
+
+#[test]
+fn test_u256() {
+    test_some_large::<U256>();
+}
+
+#[test]
 fn test_i8() {
     test_some::<i8>()
 }
@@ -77,6 +120,16 @@ fn test_i32() {
 #[test]
 fn test_i64() {
     test_some::<i64>()
+}
+
+#[test]
+fn test_i128() {
+    test_some::<i128>()
+}
+
+#[test]
+fn test_i256() {
+    test_some_large::<I256>()
 }
 
 #[test]

--- a/components/micromarshal/tests/it/statbuffer.rs
+++ b/components/micromarshal/tests/it/statbuffer.rs
@@ -14,6 +14,8 @@
 
 use std::fmt::Debug;
 
+use ethnum::{I256, U256};
+
 pub trait StatBuffer {
     type Buffer: AsMut<[u8]> + AsRef<[u8]> + Copy + Sync + Debug;
     fn buffer() -> Self::Buffer;
@@ -51,6 +53,22 @@ impl StatBuffer for u64 {
     }
 }
 
+impl StatBuffer for u128 {
+    type Buffer = [u8; 16];
+
+    fn buffer() -> Self::Buffer {
+        [0; 16]
+    }
+}
+
+impl StatBuffer for U256 {
+    type Buffer = [u8; 32];
+
+    fn buffer() -> Self::Buffer {
+        [0; 32]
+    }
+}
+
 impl StatBuffer for i8 {
     type Buffer = [u8; 1];
 
@@ -80,6 +98,22 @@ impl StatBuffer for i64 {
 
     fn buffer() -> Self::Buffer {
         [0; 8]
+    }
+}
+
+impl StatBuffer for i128 {
+    type Buffer = [u8; 16];
+
+    fn buffer() -> Self::Buffer {
+        [0; 16]
+    }
+}
+
+impl StatBuffer for I256 {
+    type Buffer = [u8; 32];
+
+    fn buffer() -> Self::Buffer {
+        [0; 32]
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Make `i128`/`u128`/`I256`/`U256` can be (un)marshalled.

**NOTE**: `I256` and `U256` are from crate `ethnum`.

