### PR TITLE
chore: update tokio-rustls to 0.24

### DIFF
--- a/mysql/Cargo.toml
+++ b/mysql/Cargo.toml
@@ -24,7 +24,7 @@ chrono = "0.4.20"
 mysql_common = { version = "0.29.0", features = ["chrono"] }
 nom = "7.1.0"
 tokio = { version = "1.17.0", features = ["io-util", "io-std"] }
-tokio-rustls = { version = "0.23.4", optional = true }
+tokio-rustls = { version = "0.24", optional = true }
 pin-project-lite = { version = "0.2.9", optional = true }
 
 [dev-dependencies]
@@ -48,4 +48,3 @@ path = "examples/serve_one.rs"
 [[example]]
 name = "serve_secure"
 path = "examples/serve_secure.rs"
-


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Update rustls library family
