### PR TITLE
feat: update rustls libraries

### DIFF
--- a/mysql/Cargo.toml
+++ b/mysql/Cargo.toml
@@ -24,7 +24,7 @@ chrono = "0.4.20"
 mysql_common = { version = "0.31.0", features = ["chrono"] }
 nom = "7.1.0"
 tokio = { version = "1.17.0", features = ["io-util", "io-std"] }
-tokio-rustls = { version = "0.24", optional = true }
+tokio-rustls = { version = "0.25", optional = true }
 pin-project-lite = { version = "0.2.9", optional = true }
 
 [dev-dependencies]
@@ -35,7 +35,8 @@ futures = "0.3"
 rcgen = "0.11"
 tempfile = "3.3.0"
 native-tls = "0.2.8"
-rustls-pemfile = { version = "1.0" }
+rustls-pemfile = { version = "2.0" }
+rustls-pki-types = "1.0"
 
 [[example]]
 name = "serve_auth"

--- a/mysql/examples/serve_secure.rs
+++ b/mysql/examples/serve_secure.rs
@@ -22,13 +22,14 @@
 mod tls {
 
     use rustls_pemfile::{certs, pkcs8_private_keys};
+    use rustls_pki_types::{CertificateDer, PrivateKeyDer};
     use std::{
         fs::File,
         io::{self, BufReader, ErrorKind},
         sync::Arc,
     };
     use tokio::io::AsyncWrite;
-    use tokio_rustls::rustls::{Certificate, PrivateKey, ServerConfig};
+    use tokio_rustls::rustls::ServerConfig;
 
     use opensrv_mysql::*;
     use tokio::net::TcpListener;
@@ -72,16 +73,16 @@ mod tls {
         let cert = certs(&mut BufReader::new(File::open(
             "mysql/tests/ssl/server.crt",
         )?))
-        .map_err(|_| io::Error::new(ErrorKind::InvalidInput, "invalid cert"))
-        .map(|mut certs| certs.drain(..).map(Certificate).collect())?;
+        .collect::<Result<Vec<CertificateDer>, io::Error>>()?;
+
         let key = pkcs8_private_keys(&mut BufReader::new(File::open(
             "mysql/tests/ssl/server.key",
         )?))
-        .map_err(|_| io::Error::new(ErrorKind::InvalidInput, "invalid key"))
-        .map(|mut keys| keys.drain(..).map(PrivateKey).next().unwrap())?;
+        .map(|key| key.map(PrivateKeyDer::from))
+        .collect::<Result<Vec<PrivateKeyDer>, io::Error>>()?
+        .remove(0);
 
         let config = ServerConfig::builder()
-            .with_safe_defaults()
             .with_no_client_auth()
             .with_single_cert(cert, key)
             .map_err(|err| io::Error::new(ErrorKind::InvalidInput, err))?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This patch updates rustls to 0.22 together with its library family.

