### PR TITLE
correctly decode mysql binary timestamp

### DIFF
--- a/mysql/src/lib.rs
+++ b/mysql/src/lib.rs
@@ -98,7 +98,7 @@ pub struct OkResponse {
 pub use crate::errorcodes::ErrorKind;
 pub use crate::params::{ParamParser, ParamValue, Params};
 pub use crate::resultset::{InitWriter, QueryResultWriter, RowWriter, StatementMetaWriter};
-pub use crate::value::{ToMysqlValue, Value, ValueInner};
+pub use crate::value::{decode::to_naive_datetime, ToMysqlValue, Value, ValueInner};
 use crate::{commands::ClientHandshake, packet_reader::PacketReader, packet_writer::PacketWriter};
 
 const SCRAMBLE_SIZE: usize = 20;

--- a/mysql/src/value/decode.rs
+++ b/mysql/src/value/decode.rs
@@ -240,15 +240,19 @@ impl<'a> From<Value<'a>> for NaiveDateTime {
 }
 
 pub fn to_naive_datetime(val: Value) -> Result<NaiveDateTime, io::Error> {
-    let ValueInner::Datetime(mut v) = val.0 else {
+    let ValueInner::Datetime(v) = val.0 else {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("invalid type conversion from {:?} to datetime", val),
         ))
     };
 
+    let len = v.len();
+
+    let v = &mut io::Cursor::new(v);
+
     // unwrap safety: guarded by `v.len()` check
-    fn read_ymd(mut v: &[u8]) -> (i32, u32, u32) {
+    fn read_ymd(v: &mut io::Cursor<&[u8]>) -> (i32, u32, u32) {
         let y = i32::from(v.read_u16::<LittleEndian>().unwrap());
         let m = u32::from(v.read_u8().unwrap());
         let d = u32::from(v.read_u8().unwrap());
@@ -256,7 +260,7 @@ pub fn to_naive_datetime(val: Value) -> Result<NaiveDateTime, io::Error> {
     }
 
     // unwrap safety: guarded by `v.len()` check
-    fn read_hms(mut v: &[u8]) -> (u32, u32, u32) {
+    fn read_hms(v: &mut io::Cursor<&[u8]>) -> (u32, u32, u32) {
         let h = u32::from(v.read_u8().unwrap());
         let m = u32::from(v.read_u8().unwrap());
         let s = u32::from(v.read_u8().unwrap());
@@ -265,7 +269,7 @@ pub fn to_naive_datetime(val: Value) -> Result<NaiveDateTime, io::Error> {
 
     // Timestamp binary encoding:
     // https://mariadb.com/kb/en/resultset-row/#timestamp-binary-encoding
-    let d = match v.len() {
+    let d = match len {
         0 => {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -297,7 +301,7 @@ pub fn to_naive_datetime(val: Value) -> Result<NaiveDateTime, io::Error> {
         _ => {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("illegal length of timestamp value: {}", v.len()),
+                format!("illegal timestamp value length: {}", len),
             ))
         }
     };

--- a/mysql/src/value/decode.rs
+++ b/mysql/src/value/decode.rs
@@ -244,7 +244,7 @@ pub fn to_naive_datetime(val: Value) -> Result<NaiveDateTime, io::Error> {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("invalid type conversion from {:?} to datetime", val),
-        ))
+        ));
     };
 
     let len = v.len();

--- a/mysql/src/value/decode.rs
+++ b/mysql/src/value/decode.rs
@@ -235,29 +235,79 @@ impl<'a> From<Value<'a>> for NaiveDate {
 
 impl<'a> From<Value<'a>> for NaiveDateTime {
     fn from(val: Value<'a>) -> Self {
-        if let ValueInner::Datetime(mut v) = val.0 {
-            assert!(v.len() == 7 || v.len() == 11);
-            let d = NaiveDate::from_ymd_opt(
-                i32::from(v.read_u16::<LittleEndian>().unwrap()),
-                u32::from(v.read_u8().unwrap()),
-                u32::from(v.read_u8().unwrap()),
-            )
-            .unwrap();
-
-            let h = u32::from(v.read_u8().unwrap());
-            let m = u32::from(v.read_u8().unwrap());
-            let s = u32::from(v.read_u8().unwrap());
-
-            if v.len() == 11 {
-                let us = v.read_u32::<LittleEndian>().unwrap();
-                d.and_hms_micro_opt(h, m, s, us).unwrap()
-            } else {
-                d.and_hms_opt(h, m, s).unwrap()
-            }
-        } else {
-            panic!("invalid type conversion from {:?} to datetime", val)
-        }
+        to_naive_datetime(val).unwrap()
     }
+}
+
+pub fn to_naive_datetime(val: Value) -> Result<NaiveDateTime, io::Error> {
+    let ValueInner::Datetime(mut v) = val.0 else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid type conversion from {:?} to datetime", val),
+        ))
+    };
+
+    // unwrap safety: guarded by `v.len()` check
+    fn read_ymd(mut v: &[u8]) -> (i32, u32, u32) {
+        let y = i32::from(v.read_u16::<LittleEndian>().unwrap());
+        let m = u32::from(v.read_u8().unwrap());
+        let d = u32::from(v.read_u8().unwrap());
+        (y, m, d)
+    }
+
+    // unwrap safety: guarded by `v.len()` check
+    fn read_hms(mut v: &[u8]) -> (u32, u32, u32) {
+        let h = u32::from(v.read_u8().unwrap());
+        let m = u32::from(v.read_u8().unwrap());
+        let s = u32::from(v.read_u8().unwrap());
+        (h, m, s)
+    }
+
+    // Timestamp binary encoding:
+    // https://mariadb.com/kb/en/resultset-row/#timestamp-binary-encoding
+    let d = match v.len() {
+        0 => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "'0000-00-00 00:00:00' is a valid timestamp value but not representable by NaiveDateTime!",
+            ))
+        }
+        4 => {
+            let (y, m, d) = read_ymd(v);
+            NaiveDate::from_ymd_opt(y, m, d).and_then(|x| x.and_hms_opt(0, 0, 0))
+        }
+        7 => {
+            let (y, m, d) = read_ymd(v);
+            NaiveDate::from_ymd_opt(y, m, d).and_then(|x| {
+                let (h, m, s) = read_hms(v);
+                x.and_hms_opt(h, m, s)
+            })
+        }
+        11 => {
+            let (y, m, d) = read_ymd(v);
+            NaiveDate::from_ymd_opt(y, m, d).and_then(|x| {
+                let (h, m, s) = read_hms(v);
+
+                // unwrap safety: guarded by `v.len()` check
+                let us = v.read_u32::<LittleEndian>().unwrap();
+
+                x.and_hms_micro_opt(h, m, s, us)
+            })
+        }
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("illegal length of timestamp value: {}", v.len()),
+            ))
+        }
+    };
+
+    d.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid data conversion from {:?} to datetime", val),
+        )
+    })
 }
 
 use std::time::Duration;

--- a/mysql/src/value/mod.rs
+++ b/mysql/src/value/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod decode;
+pub(crate) mod decode;
 mod encode;
 
 pub use self::decode::{Value, ValueInner};


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Correctly decode mysql binary timestamp, and easier error handling for caller.

close #59