### PR TITLE
feat: update rustls to 0.23

### DIFF
--- a/mysql/Cargo.toml
+++ b/mysql/Cargo.toml
@@ -24,7 +24,7 @@ chrono = "0.4.20"
 mysql_common = { version = "0.32.0", features = ["chrono"] }
 nom = "7.1.0"
 tokio = { version = "1.17.0", features = ["io-util", "io-std"] }
-tokio-rustls = { version = "0.25", optional = true }
+tokio-rustls = { version = "0.26", optional = true }
 pin-project-lite = { version = "0.2.9", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Just upgrade rustls to 0.23

