### PR TITLE
fix: Use After Free in PacketReader

### DIFF
--- a/mysql/Cargo.toml
+++ b/mysql/Cargo.toml
@@ -20,7 +20,7 @@ tls = ["tokio-rustls", "pin-project-lite"]
 [dependencies]
 async-trait = "0.1.52"
 byteorder = "1.4.3"
-bytes = "1.7.1"
+bytes = "1"
 chrono = "0.4.20"
 mysql_common = { version = "0.32.0", features = ["chrono"] }
 nom = "7.1.0"

--- a/mysql/Cargo.toml
+++ b/mysql/Cargo.toml
@@ -20,7 +20,7 @@ tls = ["tokio-rustls", "pin-project-lite"]
 [dependencies]
 async-trait = "0.1.52"
 byteorder = "1.4.3"
-bytes = "1"
+bytes = "1.7.0"
 chrono = "0.4.20"
 mysql_common = { version = "0.32.0", features = ["chrono"] }
 nom = "7.1.0"

--- a/mysql/Cargo.toml
+++ b/mysql/Cargo.toml
@@ -20,6 +20,7 @@ tls = ["tokio-rustls", "pin-project-lite"]
 [dependencies]
 async-trait = "0.1.52"
 byteorder = "1.4.3"
+bytes = "1.7.1"
 chrono = "0.4.20"
 mysql_common = { version = "0.32.0", features = ["chrono"] }
 nom = "7.1.0"

--- a/mysql/src/packet_reader.rs
+++ b/mysql/src/packet_reader.rs
@@ -85,6 +85,7 @@ impl<R: Read> PacketReader<R> {
                 // coping `bytes::Bytes` are very cheap, just move the pointer and increase the ref count.
                 match packet(self.bytes.clone().into()) {
                     Ok((rest, p)) => {
+                        // most time the `rest` is either empty or very small, so it's cheap to copy it later into next buffer
                         self.bytes = rest.into();
                         return Ok(Some(p));
                     }

--- a/mysql/src/packet_reader.rs
+++ b/mysql/src/packet_reader.rs
@@ -15,25 +15,36 @@
 use std::io;
 use std::io::prelude::*;
 
+use std::iter::Enumerate;
+use std::marker::PhantomData;
+use std::ops::RangeFrom;
+
+use bytes::BytesMut;
+use nom::Needed;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncReadExt;
 
 const PACKET_BUFFER_SIZE: usize = 4_096;
 const PACKET_LARGE_BUFFER_SIZE: usize = 1_048_576;
 
+fn calc_new_buf_size(last_buf_size: usize) -> usize {
+    if last_buf_size >= PACKET_BUFFER_SIZE * 2 {
+        // if packet is already too large, use larger buffer to avoid multiple allocation
+        PACKET_LARGE_BUFFER_SIZE
+    } else {
+        std::cmp::max(PACKET_BUFFER_SIZE, last_buf_size * 2)
+    }
+}
+
 pub struct PacketReader<R> {
-    bytes: Vec<u8>,
-    start: usize,
-    remaining: usize,
+    bytes: bytes::Bytes,
     pub r: R,
 }
 
 impl<R> PacketReader<R> {
     pub fn new(r: R) -> Self {
         PacketReader {
-            bytes: Vec::new(),
-            start: 0,
-            remaining: 0,
+            bytes: bytes::Bytes::new(),
             r,
         }
     }
@@ -42,22 +53,12 @@ impl<R> PacketReader<R> {
 impl<R: Read> PacketReader<R> {
     #[allow(dead_code)]
     pub fn next(&mut self) -> io::Result<Option<(u8, Packet<'_>)>> {
-        self.start = self.bytes.len() - self.remaining;
-
         loop {
-            if self.remaining != 0 {
-                let bytes = {
-                    // NOTE: this is all sorts of unfortunate. what we really want to do is to give
-                    // &self.bytes[self.start..] to `packet()`, and the lifetimes should all work
-                    // out. however, without NLL, borrowck doesn't realize that self.bytes is no
-                    // longer borrowed after the match, and so can be mutated.
-                    let bytes = &self.bytes[self.start..];
-                    unsafe { ::std::slice::from_raw_parts(bytes.as_ptr(), bytes.len()) }
-                };
-
-                match packet(bytes) {
+            if !self.bytes.is_empty() {
+                // coping `bytes::Bytes` are very cheap, just move the pointer and increase the ref count.
+                match packet(self.bytes.clone().into()) {
                     Ok((rest, p)) => {
-                        self.remaining = rest.len();
+                        self.bytes = rest.into();
                         return Ok(Some(p));
                     }
                     Err(nom::Err::Incomplete(_)) | Err(nom::Err::Error(_)) => {}
@@ -66,25 +67,25 @@ impl<R: Read> PacketReader<R> {
                             io::ErrorKind::InvalidData,
                             format!("{:?}", ctx),
                         ));
-                        self.bytes.truncate(self.remaining);
                         return err;
                     }
                 }
             }
 
-            // we need to read some more
-            self.bytes.drain(0..self.start);
-            self.start = 0;
-            let end = self.bytes.len();
-            self.bytes.resize(std::cmp::max(4096, end * 2), 0);
-            let read = {
-                let buf = &mut self.bytes[end..];
-                self.r.read(buf)?
-            };
-            self.bytes.truncate(end + read);
-            self.remaining = self.bytes.len();
+            // read more buffer
+            let last_buffer_size = self.bytes.len();
+            // allocate new buffer if old buffer have packets that is still in use.
+            // notice if old buffer have no alive packet, it's space will get reused.
+            let mut buf = std::mem::take(&mut self.bytes)
+                .try_into_mut()
+                .unwrap_or_else(|_| BytesMut::with_capacity(calc_new_buf_size(last_buffer_size)));
 
-            if read == 0 {
+            let read_cnt = self.r.read(&mut buf)?;
+            buf.truncate(read_cnt);
+            self.bytes = buf.freeze();
+
+            // for a [TcpStream], returning zero indicates the connection was shut down correctly.
+            if read_cnt == 0 {
                 if self.bytes.is_empty() {
                     return Ok(None);
                 } else {
@@ -104,11 +105,10 @@ impl<R: AsyncRead + Unpin> AsyncRead for PacketReader<R> {
         cx: &mut std::task::Context<'_>,
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> std::task::Poll<io::Result<()>> {
-        if self.remaining != 0 {
-            buf.put_slice(&self.bytes[self.start..]);
+        // if our buffer have content, send those immediately
+        if !self.bytes.is_empty() {
+            buf.put_slice(&self.bytes);
             self.bytes.clear();
-            self.start = 0;
-            self.remaining = 0;
             std::task::Poll::Ready(Ok(()))
         } else {
             std::pin::Pin::new(&mut self.r).poll_read(cx, buf)
@@ -118,31 +118,15 @@ impl<R: AsyncRead + Unpin> AsyncRead for PacketReader<R> {
 
 impl<R: AsyncRead + Unpin> PacketReader<R> {
     pub async fn next_async(&mut self) -> io::Result<Option<(u8, Packet<'_>)>> {
-        self.start = self.bytes.len() - self.remaining;
-
-        let mut buffer_size = PACKET_BUFFER_SIZE;
         loop {
-            if self.remaining != 0 {
-                let bytes = {
-                    // NOTE: this is all sorts of unfortunate. what we really want to do is to give
-                    // &self.bytes[self.start..] to `packet()`, and the lifetimes should all work
-                    // out. however, without NLL, borrowck doesn't realize that self.bytes is no
-                    // longer borrowed after the match, and so can be mutated.
-                    let bytes = &self.bytes[self.start..];
-                    unsafe { ::std::slice::from_raw_parts(bytes.as_ptr(), self.remaining) }
-                };
-                match packet(bytes) {
+            if !self.bytes.is_empty() {
+                match packet(self.bytes.clone().into()) {
                     Ok((rest, p)) => {
-                        self.remaining = rest.len();
-                        if self.remaining > 0 {
-                            self.bytes = rest.to_vec();
-                            self.start = 0;
-                        }
+                        self.bytes = rest.into();
                         return Ok(Some(p));
                     }
                     Err(nom::Err::Incomplete(_)) | Err(nom::Err::Error(_)) => {}
                     Err(nom::Err::Failure(ctx)) => {
-                        self.bytes.truncate(self.remaining);
                         return Err(io::Error::new(
                             io::ErrorKind::InvalidData,
                             format!("{:?}", ctx),
@@ -151,25 +135,20 @@ impl<R: AsyncRead + Unpin> PacketReader<R> {
                 }
             }
 
-            // we need to read some more
-            self.bytes.drain(0..self.start);
-            self.start = 0;
-            let end = self.remaining;
+            // read more buffer
+            let last_buffer_size = self.bytes.len();
+            // allocate new buffer if old buffer have packets that is still in use.
+            // notice if old buffer have no alive packet, it's space will get reused.
+            let mut buf = std::mem::take(&mut self.bytes)
+                .try_into_mut()
+                .unwrap_or_else(|_| BytesMut::with_capacity(calc_new_buf_size(last_buffer_size)));
 
-            if self.bytes.len() - end < buffer_size {
-                let new_len = std::cmp::max(buffer_size, end * 2);
-                self.bytes.resize(new_len, 0);
-            }
-            let read = {
-                let buf = &mut self.bytes[end..];
-                self.r.read(buf).await?
-            };
-            self.remaining = end + read;
-            // use a larger buffer size to reduce bytes resize times.
-            buffer_size = PACKET_LARGE_BUFFER_SIZE;
+            let read_cnt = self.r.read(&mut buf).await?;
+            buf.truncate(read_cnt);
 
-            if read == 0 {
-                self.bytes.truncate(self.remaining);
+            self.bytes = buf.freeze();
+
+            if read_cnt == 0 {
                 if self.bytes.is_empty() {
                     return Ok(None);
                 } else {
@@ -183,50 +162,134 @@ impl<R: AsyncRead + Unpin> PacketReader<R> {
     }
 }
 
-pub fn fullpacket(i: &[u8]) -> nom::IResult<&[u8], (u8, &[u8])> {
-    let (i, _) = nom::bytes::complete::tag(&[0xff, 0xff, 0xff])(i)?;
+pub fn fullpacket(i: NomBytes) -> nom::IResult<NomBytes, (u8, NomBytes)> {
+    let (i, _) = nom::bytes::complete::tag(&[0xff, 0xff, 0xff][..])(i)?;
     let (i, seq) = nom::bytes::complete::take(1u8)(i)?;
     let (i, bytes) = nom::bytes::complete::take(U24_MAX)(i)?;
-    Ok((i, (seq[0], bytes)))
+    Ok((i, (seq.as_ref()[0], bytes)))
 }
 
-pub fn onepacket(i: &[u8]) -> nom::IResult<&[u8], (u8, &[u8])> {
+pub fn onepacket(i: NomBytes) -> nom::IResult<NomBytes, (u8, NomBytes)> {
     let (i, length) = nom::number::complete::le_u24(i)?;
     let (i, seq) = nom::bytes::complete::take(1u8)(i)?;
     let (i, bytes) = nom::bytes::complete::take(length)(i)?;
-    Ok((i, (seq[0], bytes)))
+    Ok((i, (seq.as_ref()[0], bytes)))
 }
 
-// Clone because of https://github.com/Geal/nom/issues/1008
-#[derive(Clone)]
-pub struct Packet<'a>(&'a [u8], Vec<u8>);
+/// Bytes wrapper for nom, allowing nom to parse bytes::Bytes
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NomBytes(bytes::Bytes);
 
-impl<'a> Packet<'a> {
-    fn extend(&mut self, bytes: &'a [u8]) {
-        if self.0.is_empty() {
-            if self.1.is_empty() {
-                // first extend
-                self.0 = bytes;
-            } else {
-                // later extend
-                self.1.extend(bytes);
-            }
+impl NomBytes {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl From<&[u8]> for NomBytes {
+    fn from(value: &[u8]) -> Self {
+        NomBytes(bytes::Bytes::copy_from_slice(value))
+    }
+}
+
+impl From<bytes::Bytes> for NomBytes {
+    fn from(value: bytes::Bytes) -> Self {
+        NomBytes(value)
+    }
+}
+
+impl From<NomBytes> for bytes::Bytes {
+    fn from(value: NomBytes) -> Self {
+        value.0
+    }
+}
+
+impl AsRef<[u8]> for NomBytes {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl nom::InputTake for NomBytes {
+    fn take(&self, count: usize) -> Self {
+        NomBytes(self.0.slice(0..count))
+    }
+
+    fn take_split(&self, count: usize) -> (Self, Self) {
+        let mut prefix = self.0.clone();
+        let suffix = prefix.split_off(count);
+        (NomBytes(prefix), NomBytes(suffix))
+    }
+}
+
+impl nom::Compare<&[u8]> for NomBytes {
+    fn compare(&self, t: &[u8]) -> nom::CompareResult {
+        self.0.as_ref().compare(t)
+    }
+
+    fn compare_no_case(&self, t: &[u8]) -> nom::CompareResult {
+        self.0.as_ref().compare_no_case(t)
+    }
+}
+
+impl nom::InputLength for NomBytes {
+    fn input_len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl nom::InputIter for NomBytes {
+    type Item = u8;
+    type Iter = Enumerate<Self::IterElem>;
+    type IterElem = bytes::buf::IntoIter<bytes::Bytes>;
+
+    #[inline]
+    fn iter_indices(&self) -> Self::Iter {
+        self.iter_elements().enumerate()
+    }
+    #[inline]
+    fn iter_elements(&self) -> Self::IterElem {
+        self.0.clone().into_iter()
+    }
+    #[inline]
+    fn position<P>(&self, predicate: P) -> Option<usize>
+    where
+        P: Fn(Self::Item) -> bool,
+    {
+        self.0.iter().position(|b| predicate(*b))
+    }
+    #[inline]
+    fn slice_index(&self, count: usize) -> Result<usize, Needed> {
+        if self.0.len() >= count {
+            Ok(count)
         } else {
-            assert!(self.1.is_empty());
-            let mut v = self.0.to_vec();
-            v.extend(bytes);
-            self.1 = v;
-            self.0 = &[];
+            Err(Needed::new(count - self.0.len()))
         }
     }
 }
 
-impl<'a> AsRef<[u8]> for Packet<'a> {
-    fn as_ref(&self) -> &[u8] {
-        if self.1.is_empty() {
-            self.0
-        } else {
-            &self.1
+impl nom::Slice<RangeFrom<usize>> for NomBytes {
+    fn slice(&self, range: RangeFrom<usize>) -> Self {
+        NomBytes(self.0.slice(range))
+    }
+}
+
+// a simple wrapper around bytes::Bytes to make sure interface stays the same
+#[derive(Clone)]
+pub struct Packet<'a> {
+    bytes: bytes::Bytes,
+    _lifetime: PhantomData<&'a ()>, // NOTE: the lifetime can be removed since Bytes mangaes the lifetime by itself
+}
+
+impl<'a> Packet<'a> {
+    fn from_bytes(bytes: bytes::Bytes) -> Self {
+        Packet {
+            bytes,
+            _lifetime: PhantomData,
         }
     }
 }
@@ -237,23 +300,24 @@ use std::ops::Deref;
 impl<'a> Deref for Packet<'a> {
     type Target = [u8];
     fn deref(&self) -> &Self::Target {
-        self.as_ref()
+        self.bytes.as_ref()
     }
 }
 
-pub(crate) fn packet(i: &[u8]) -> nom::IResult<&[u8], (u8, Packet<'_>)> {
+pub(crate) fn packet<'a>(i: NomBytes) -> nom::IResult<NomBytes, (u8, Packet<'a>)> {
     nom::combinator::map(
         nom::sequence::pair(
             nom::multi::fold_many0(
                 fullpacket,
                 || (0, None),
-                |(seq, pkt): (_, Option<Packet<'_>>), (nseq, p)| {
+                |(seq, pkt): (_, Option<BytesMut>), (nseq, p)| {
                     let pkt = if let Some(mut pkt) = pkt {
                         assert_eq!(nseq, seq + 1);
-                        pkt.extend(p);
+                        pkt.extend_from_slice(p.as_ref());
                         Some(pkt)
                     } else {
-                        Some(Packet(p, Vec::new()))
+                        // TODO: avoid copy
+                        Some(BytesMut::from(p.0))
                     };
                     (nseq, pkt)
                 },
@@ -264,12 +328,13 @@ pub(crate) fn packet(i: &[u8]) -> nom::IResult<&[u8], (u8, Packet<'_>)> {
             let seq = last.0;
             let pkt = if let Some(mut pkt) = full.1 {
                 assert_eq!(last.0, full.0 + 1);
-                pkt.extend(last.1);
-                pkt
+                pkt.extend_from_slice(last.1.as_ref());
+                pkt.freeze()
             } else {
-                Packet(last.1, Vec::new())
+                // TODO: avoid copy
+                last.1 .0
             };
-            (seq, pkt)
+            (seq, Packet::from_bytes(pkt))
         },
     )(i)
 }

--- a/mysql/src/packet_reader.rs
+++ b/mysql/src/packet_reader.rs
@@ -46,8 +46,7 @@ fn reuse_or_create_buf(old_buf: bytes::Bytes, last_buf_size: usize) -> (usize, B
     let new_buf_size = calc_new_buf_size(last_buf_size);
     match old_buf.try_into_mut() {
         Ok(mut unique) => {
-            let remain = unique.clone();
-            let len = remain.len();
+            let len = unique.len();
             debug_assert!(len <= new_buf_size);
             // resize will save old bytes unchanged and fill the rest with 0
             unique.resize(new_buf_size, 0);

--- a/mysql/src/tests/packet.rs
+++ b/mysql/src/tests/packet.rs
@@ -18,14 +18,14 @@ use crate::U24_MAX;
 #[test]
 fn test_one_ping() {
     assert_eq!(
-        onepacket(&[0x01, 0, 0, 0, 0x10]).unwrap().1,
-        (0, &[0x10][..])
+        onepacket((&[0x01, 0, 0, 0, 0x10][..]).into()).unwrap().1,
+        (0, (&[0x10][..]).into())
     );
 }
 
 #[test]
 fn test_ping() {
-    let p = packet(&[0x01, 0, 0, 0, 0x10]).unwrap().1;
+    let p = packet((&[0x01, 0, 0, 0, 0x10][..]).into()).unwrap().1;
     assert_eq!(p.0, 0);
     assert_eq!(&*p.1, &[0x10][..]);
 }
@@ -39,7 +39,7 @@ fn test_long_exact() {
     data.push(0x00);
     data.push(1);
 
-    let (rest, p) = packet(&data[..]).unwrap();
+    let (rest, p) = packet((&data[..]).into()).unwrap();
     assert!(rest.is_empty());
     assert_eq!(p.0, 1);
     assert_eq!(p.1.len(), U24_MAX);
@@ -56,7 +56,7 @@ fn test_long_more() {
     data.push(1);
     data.push(0x10);
 
-    let (rest, p) = packet(&data[..]).unwrap();
+    let (rest, p) = packet((&data[..]).into()).unwrap();
     assert!(rest.is_empty());
     assert_eq!(p.0, 1);
     assert_eq!(p.1.len(), U24_MAX + 1);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
related issue: https://github.com/datafuselabs/opensrv/issues/66
Refactor `packet_reader.rs` to avoid Use After Free due to dropping Vec<u8> while still holding packets of u8 slice from it.

- impl `NomBytes` type which allow `nom` to parse `bytes::Bytes` which is smart pointer to array of u8, hence avoid uaf
- reuse buffer whenever possible to improve performance
- make sure packet still have a lifetime arg, so to prevent breaking change to api
- correct both impl of `next()` and `next_async()` to prevent UAF or unsafe code
- add tests that run to those large packet dealing logics(Which disclosure another bug about having packet size of exactly U24_MAX would also cause `nom` to refuse parse packets due to lack of `opt`, fixed)
- `cargo test` is passed

