### PR TITLE
ci: pin to mysql@8.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install mysql-client
         if: ${{ contains(matrix.os, 'macos') }}
-        run: brew install mysql@8.4
+        run: | 
+          brew uninstall mysql 
+          brew install mysql@8.4
+          ln -s /opt/homebrew/opt/mysql@8.4 /opt/homebrew/opt/mysql
+          echo 'export PATH="/opt/homebrew/opt/mysql/bin:$PATH"' >> ~/.zshrc
       - run: cargo build
       - run: cargo test --lib --bins --tests -- --include-ignored
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Install mysql-client
         if: ${{ contains(matrix.os, 'macos') }}
         run: | 
-          brew install mysql@8.4
+          brew install mysql@8.3
           ln -s /opt/homebrew/opt/mysql@8.4 /opt/homebrew/opt/mysql
           echo 'export PATH="/opt/homebrew/opt/mysql/bin:$PATH"' >> ~/.zshrc
       - run: cargo build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,6 @@ jobs:
       - name: Install mysql-client
         if: ${{ contains(matrix.os, 'macos') }}
         run: | 
-          brew uninstall mysql 
           brew install mysql@8.4
           ln -s /opt/homebrew/opt/mysql@8.4 /opt/homebrew/opt/mysql
           echo 'export PATH="/opt/homebrew/opt/mysql/bin:$PATH"' >> ~/.zshrc


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

From MySQL 9.0, mysql_native_password is removed from built-in auth methods.
