### PR TITLE
Bump toolchain to 1.85 and update audit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,8 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install cargo-aduit
-        run: cargo install cargo-audit --version 0.21.1 --locked
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --version 0.22.0 --locked
       - name: Audit dependencies
         run: cargo audit
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,4 @@ resolver = "2"
 members = ["clickhouse", "mysql", "components/micromarshal"]
 
 [patch.crates-io]
-subprocess = "=0.2.12"
+subprocess = { git = "https://github.com/hniksic/rust-subprocess", tag = "release/0.2.9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 resolver = "2"
 members = ["clickhouse", "mysql", "components/micromarshal"]
+
+[patch.crates-io]
+subprocess = "=0.2.12"

--- a/clickhouse/Cargo.toml
+++ b/clickhouse/Cargo.toml
@@ -3,6 +3,7 @@ name = "opensrv-clickhouse"
 version = "0.7.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 edition = "2021"
+rust-version = "1.85"
 license = "Apache-2.0"
 description = "Bindings for emulating a ClickHouse server."
 readme = "README.md"

--- a/components/micromarshal/Cargo.toml
+++ b/components/micromarshal/Cargo.toml
@@ -3,6 +3,7 @@ name = "micromarshal"
 version = "0.7.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 edition = "2021"
+rust-version = "1.85"
 license = "Apache-2.0"
 description = "(De)Serialisation between Rust values and binary byte objects. "
 readme = "README.md"

--- a/mysql/Cargo.toml
+++ b/mysql/Cargo.toml
@@ -3,6 +3,7 @@ name = "opensrv-mysql"
 version = "0.8.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 edition = "2021"
+rust-version = "1.85"
 license = "Apache-2.0"
 description = "Bindings for emulating a MySQL/MariaDB server."
 readme = "README.md"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.85.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Update toolchain to Rust 1.85 and declare MSRV 1.85 in crates. Update CI cargo-audit to 0.22.0 to handle CVSS 4.0 advisories.